### PR TITLE
Update theokanning openapi gpt3 java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <!-- https://mvnrepository.com/artifact/com.theokanning.openai-gpt3-java/client -->
     <dependency>
       <groupId>com.theokanning.openai-gpt3-java</groupId>
-      <artifactId>client</artifactId>
+      <artifactId>service</artifactId>
       <version>0.12.0</version>
     </dependency>
   </dependencies>

--- a/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
+++ b/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
@@ -1,7 +1,7 @@
 package com.streisky.discordchatgptbot.openai;
 
-import com.theokanning.openai.OpenAiService;
 import com.theokanning.openai.completion.CompletionRequest;
+import com.theokanning.openai.service.OpenAiService;
 
 public class OpenAIApi {
 


### PR DESCRIPTION
The service class is deprecated in favor of the class from the service module.
[source](https://github.com/TheoKanning/openai-java)

This PR replaces the service class from the client `module `with the one in the `service` module.