### PR TITLE
Use Java 11 as the target version from the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,39 +1,51 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.example</groupId>
-  <artifactId>DiscordChatGPTBot</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>org.example</groupId>
+    <artifactId>DiscordChatGPTBot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>DiscordChatGPTBot</name>
-  <url>http://maven.apache.org</url>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
+    <name>DiscordChatGPTBot</name>
+    <url>http://maven.apache.org</url>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/net.dv8tion/JDA -->
-    <dependency>
-      <groupId>net.dv8tion</groupId>
-      <artifactId>JDA</artifactId>
-      <version>5.0.0-beta.9</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/com.theokanning.openai-gpt3-java/client -->
-    <dependency>
-      <groupId>com.theokanning.openai-gpt3-java</groupId>
-      <artifactId>service</artifactId>
-      <version>0.12.0</version>
-    </dependency>
-  </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/net.dv8tion/JDA -->
+        <dependency>
+            <groupId>net.dv8tion</groupId>
+            <artifactId>JDA</artifactId>
+            <version>5.0.0-beta.9</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.theokanning.openai-gpt3-java/client -->
+        <dependency>
+            <groupId>com.theokanning.openai-gpt3-java</groupId>
+            <artifactId>service</artifactId>
+            <version>0.12.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- https://mvnrepository.com/artifact/com.theokanning.openai-gpt3-java/client -->
         <dependency>
             <groupId>com.theokanning.openai-gpt3-java</groupId>
-            <artifactId>service</artifactId>
+            <artifactId>client</artifactId>
             <version>0.12.0</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <!-- https://mvnrepository.com/artifact/com.theokanning.openai-gpt3-java/client -->
     <dependency>
       <groupId>com.theokanning.openai-gpt3-java</groupId>
-      <artifactId>client</artifactId>
+      <artifactId>service</artifactId>
       <version>0.12.0</version>
     </dependency>
   </dependencies>

--- a/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
+++ b/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
@@ -1,7 +1,7 @@
 package com.streisky.discordchatgptbot.openai;
 
+import com.theokanning.openai.OpenAiService;
 import com.theokanning.openai.completion.CompletionRequest;
-import com.theokanning.openai.service.OpenAiService;
 
 public class OpenAIApi {
 

--- a/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
+++ b/src/main/java/com/streisky/discordchatgptbot/openai/OpenAIApi.java
@@ -1,7 +1,7 @@
 package com.streisky.discordchatgptbot.openai;
 
-import com.theokanning.openai.OpenAiService;
 import com.theokanning.openai.completion.CompletionRequest;
+import com.theokanning.openai.service.OpenAiService;
 
 public class OpenAIApi {
 


### PR DESCRIPTION
The project does not have a set  version to run. Adding the specific version will guarantee that all developers run the project with the same Java sources and will avoid problems such as failing to compile due trying to run with versions that are too old.

For clarifying and giving an example,  `@Override` on a method implementing an interface is not allowed in Java before version 6. And without clearly defining the Java version a compile error could occur.

Obs: Also, this PR formats the maven pom.xml with the default 4 spaces indentation (default on IntelliJ).